### PR TITLE
Enable root-level imports for project modules

### DIFF
--- a/document.py
+++ b/document.py
@@ -1,0 +1,1 @@
+from group_038_p2.document import *

--- a/my_module.py
+++ b/my_module.py
@@ -1,0 +1,1 @@
+from group_038_p2.my_module import *

--- a/porter_stemmer.py
+++ b/porter_stemmer.py
@@ -1,0 +1,1 @@
+from group_038_p2.porter_stemmer import *

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,5 @@
+import os, sys
+root = os.path.dirname(__file__)
+if sys.path[0] != root:
+    if root not in sys.path:
+        sys.path.insert(0, root)

--- a/test_wrapper.py
+++ b/test_wrapper.py
@@ -1,0 +1,1 @@
+from group_038_p2.test_wrapper import *


### PR DESCRIPTION
## Summary
- expose `document`, `my_module`, `test_wrapper`, and `porter_stemmer` at repository root
- add a package marker for `group_038_p2`
- ensure repository root is added to `sys.path` via `sitecustomize`

## Testing
- `PYTHONPATH=. pytest -q group_038_p2/public_tests/test_pr03_t1.py group_038_p2/public_tests/test_pr03_t2.py group_038_p2/public_tests/test_pr03_t3.py`
- `PYTHONPATH=. pytest -q group_038_p2/public_tests/test_pr02_t3.py group_038_p2/public_tests/test_pr02_t4.py`


------
https://chatgpt.com/codex/tasks/task_e_687a9cf026fc8320a5164b9393a5dc7b